### PR TITLE
Fix control panel layout spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,10 @@
                     <p class="panel__subtitle">Set your luck profile, biome, and roll counts.</p>
                 </header>
 
+                <div class="control-group control-group--cta">
+                    <button class="roll-button" type="button" onclick="roll()">Start Rolling</button>
+                </div>
+
                 <section class="control-group">
                     <h3 class="control-group__title">Luck Multipliers</h3>
                     <label class="field" for="vip-select">
@@ -186,9 +190,6 @@
                     </div>
                 </section>
 
-                <div class="control-group control-group--cta">
-                    <button class="roll-button" type="button" onclick="roll()">Start Rolling</button>
-                </div>
             </aside>
         </div>
 

--- a/style.css
+++ b/style.css
@@ -193,6 +193,7 @@ body {
     display: grid;
     grid-template-columns: minmax(220px, 260px) minmax(420px, 1fr) minmax(320px, 360px);
     gap: clamp(16px, 2vw, 24px);
+    align-items: start;
 }
 
 .panel--results {
@@ -362,6 +363,17 @@ body {
 .field__combo {
     display: flex;
     gap: 10px;
+    align-items: center;
+    flex-wrap: wrap;
+}
+
+.field__combo .field__input {
+    min-width: 0;
+}
+
+.field__combo .ui-button {
+    flex-shrink: 0;
+    white-space: nowrap;
 }
 
 .field__input {


### PR DESCRIPTION
## Summary
- move the start rolling button directly above the luck multipliers section for improved hierarchy
- prevent the controls grid from stretching side panels to full height and allow reset buttons to keep their full width

## Testing
- No tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd0fcaec3c8321a729382b29283c3c