### PR TITLE
Add biome-specific biome assets and limbo roll sound

### DIFF
--- a/func.js
+++ b/func.js
@@ -47,6 +47,9 @@ function toggleSound() {
     const bgMusic = document.getElementById('bgMusic');
     const soundToggle = document.getElementById('soundToggle');
     bgMusic.volume = 0.02;
+    if (bgMusic && !bgMusic.getAttribute('data-current-src')) {
+        bgMusic.setAttribute('data-current-src', bgMusic.src);
+    }
 
     if (soundEnabled) {
         playSound(document.getElementById('clickSound'));
@@ -90,6 +93,62 @@ let currentLuck = 1;
 let lastVipMultiplier = 1;
 let lastXyzMultiplier = 1;
 let lastDaveMultiplier = 1;
+
+const biomeAssets = {
+    normal: { image: 'files/normalBiomeImage.jpg', music: 'files/normalBiomeMusic.mp3' },
+    day: { image: 'files/dayBiomeImage.jpg', music: 'files/dayBiomeMusic.mp3' },
+    night: { image: 'files/nightBiomeImage.jpg', music: 'files/nightBiomeMusic.mp3' },
+    rainy: { image: 'files/rainyBiomeImage.jpg', music: 'files/rainyBiomeMusic.mp3' },
+    windy: { image: 'files/windyBiomeImage.jpg', music: 'files/windyBiomeMusic.mp3' },
+    snowy: { image: 'files/snowyBiomeImage.jpg', music: 'files/winterBiomeMusic.mp3' },
+    sandstorm: { image: 'files/sandstormBiomeImage.jpg', music: 'files/sandstormBiomeMusic.mp3' },
+    hell: { image: 'files/hellBiomeImage.jpg', music: 'files/hellBiomeMusic.mp3' },
+    starfall: { image: 'files/starfallBiomeImage.jpg', music: 'files/starfallBiomeMusic.mp3' },
+    corruption: { image: 'files/corruptionBiomeImage.jpg', music: 'files/corruptionBiomeMusic.mp3' },
+    null: { image: 'files/nullBiomeImage.jpg', music: 'files/nullBiomeMusic.mp3' },
+    dreamspace: { image: 'files/dreamspaceBiomeImage.jpg', music: 'files/dreamspaceBiomeMusic.mp3' },
+    glitch: { image: 'files/glitchBiomeImage.jpg', music: 'files/glitchBiomeMusic.mp3' },
+    limbo: { image: 'files/limboImage.jpg', music: 'files/limboMusic.mp3' },
+    blazing: { image: 'files/blazingBiomeImage.jpg', music: 'files/blazingBiomeMusic.mp3' }
+};
+
+function applyBiomeTheme(biome) {
+    const assetKey = Object.prototype.hasOwnProperty.call(biomeAssets, biome) ? biome : 'normal';
+    const assets = biomeAssets[assetKey];
+
+    const root = document.documentElement;
+    if (root) {
+        root.style.setProperty('--biome-background', `url("${assets.image}")`);
+    }
+
+    const backdrop = document.querySelector('.ui-backdrop');
+    if (backdrop) {
+        backdrop.style.backgroundImage = `url("${assets.image}")`;
+    }
+
+    const bgMusic = document.getElementById('bgMusic');
+    if (bgMusic) {
+        const currentSrc = bgMusic.getAttribute('data-current-src');
+        const shouldUpdateMusic = currentSrc !== assets.music;
+        const wasPlaying = soundEnabled && !bgMusic.paused;
+
+        if (shouldUpdateMusic) {
+            bgMusic.pause();
+            bgMusic.currentTime = 0;
+            bgMusic.src = assets.music;
+            bgMusic.setAttribute('data-current-src', assets.music);
+            bgMusic.load();
+        }
+
+        if (wasPlaying && (shouldUpdateMusic || bgMusic.paused)) {
+            bgMusic.muted = false;
+            const playPromise = bgMusic.play();
+            if (playPromise && typeof playPromise.catch === 'function') {
+                playPromise.catch(() => {});
+            }
+        }
+    }
+}
 
 function setLuck(value) {
     baseLuck = value;
@@ -195,6 +254,7 @@ function handleBiomeUI() {
             });
         }
     }
+    applyBiomeTheme(biome);
     updateLuckValue();
 }
 

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
         <div class="ui-backdrop__veil"></div>
     </div>
 
-    <audio id="bgMusic" loop muted src="files/SolsBgMusic.mp3" type="audio/mpeg"></audio>
+    <audio id="bgMusic" loop muted src="files/normalBiomeMusic.mp3" type="audio/mpeg"></audio>
     <audio id="rollSound" loop muted src="files/SolsRollSound.mp3" type="audio/mpeg"></audio>
     <audio id="clickSound" loop muted src="files/SolsClickSound.mp3" type="audio/mpeg"></audio>
     <audio id="hoverSound" loop muted src="files/SolsHoverSound.mp3" type="audio/mpeg"></audio>
@@ -23,6 +23,7 @@
     <audio id="100kSound" loop muted src="files/100_000Roll.ogg" type="audio/ogg"></audio>
     <audio id="10mSound" loop muted src="files/10_000_000Roll.ogg" type="audio/ogg"></audio>
     <audio id="100mSound" loop muted src="files/100_000_000Roll.ogg" type="audio/ogg"></audio>
+    <audio id="limbo99mSound" loop muted src="files/99mLimboRollSound.mp3" type="audio/mpeg"></audio>
 
     <video id="equinox-cs" class="aura-video" preload="auto">
         <source src="files/equinoxCutscene.webm" type="video/webm">

--- a/script.js
+++ b/script.js
@@ -341,7 +341,11 @@ function roll() {
             }
 
             if (highestChance >= 99999999) {
-                playSound(document.getElementById('100mSound'));
+                if (biome === 'limbo') {
+                    playSound(document.getElementById('limbo99mSound'));
+                } else {
+                    playSound(document.getElementById('100mSound'));
+                }
             } else if (highestChance >= 10000000) {
                 playSound(document.getElementById('10mSound'));
             } else if (highestChance >= 100000) {

--- a/style.css
+++ b/style.css
@@ -48,7 +48,7 @@ body {
     position: fixed;
     inset: 0;
     background-color: var(--bg-base);
-    background-image: url("files/SolsBgImage.jpg");
+    background-image: var(--biome-background, url("files/normalBiomeImage.jpg"));
     background-position: center top;
     background-repeat: no-repeat;
     background-size: 100% 100%;


### PR DESCRIPTION
## Summary
- swap the default backdrop and music assets to the new biome-specific files
- automatically swap background images and looping music as the biome selector changes
- trigger the special limbo 99,999,999+ roll sound instead of the generic 100m sound

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_e_68dd671dd9588321b4e463dd09194146