### PR TITLE
Align roll feed tip and mythic signature on one row

### DIFF
--- a/index.html
+++ b/index.html
@@ -95,8 +95,10 @@
                 <div class="results__viewport" id="result-text" role="status" aria-live="polite">
                     Configure your parameters and launch a simulation to see results.
                 </div>
-                <p class="results__tip"><span class="results__tip-label">[Tip] Suzy:</span> Get Lucky</p>
-                <p class="results__mythic"><span class="results__mythic-label">MythicDude</span> was here...</p>
+                <div class="results__meta">
+                    <p class="results__tip"><span class="results__tip-label">[Tip] Suzy:</span> Get Lucky</p>
+                    <p class="results__mythic"><span class="results__mythic-label">MythicDude</span> was here...</p>
+                </div>
             </main>
 
             <aside class="panel panel--controls" aria-labelledby="controls-title">

--- a/style.css
+++ b/style.css
@@ -265,8 +265,16 @@ body {
     gap: clamp(14px, 2vw, 20px);
 }
 
+.results__meta {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: clamp(12px, 2vw, 24px);
+    margin-top: clamp(8px, 1.6vw, 16px);
+}
+
 .results__tip {
-    margin: clamp(8px, 1.6vw, 16px) 0 0;
+    margin: 0;
     font-size: clamp(12px, 1.6vw, 14px);
     letter-spacing: 0.18em;
     text-transform: uppercase;
@@ -279,16 +287,17 @@ body {
 }
 
 .results__mythic {
-    margin: clamp(8px, 1.6vw, 16px) 0 0;
+    margin: 0;
     font-size: clamp(8px, 1.6vw, 10px);
     letter-spacing: 0.18em;
     text-transform: uppercase;
-    color: var(--text-secondary);
+    color: rgba(199, 219, 255, 0.8);
+    text-align: right;
 }
 
 .results__mythic-label {
-    color: rgb(46, 255, 238);
-    margin-left: 8px;
+    color: rgba(46, 255, 238, 0.8);
+    margin-right: 8px;
 }
 
 .panel__header {


### PR DESCRIPTION
## Summary
- wrap the roll feed tip and mythic signature in a shared meta row container
- use flex layout so Suzy's tip and the MythicDude signature sit on the same line at opposite sides

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd6f4f5c808321974e77f62f7df373