### PR TITLE
Add Rune of Everything biome mode

### DIFF
--- a/func.js
+++ b/func.js
@@ -268,6 +268,7 @@ let lastDaveMultiplier = 1;
 
 const biomeAssets = {
     normal: { image: 'files/normalBiomeImage.jpg', music: 'files/normalBiomeMusic.mp3' },
+    roe: { image: 'files/normalBiomeImage.jpg', music: 'files/normalBiomeMusic.mp3' },
     day: { image: 'files/dayBiomeImage.jpg', music: 'files/dayBiomeMusic.mp3' },
     night: { image: 'files/nightBiomeImage.jpg', music: 'files/nightBiomeMusic.mp3' },
     rainy: { image: 'files/rainyBiomeImage.jpg', music: 'files/rainyBiomeMusic.mp3' },

--- a/index.html
+++ b/index.html
@@ -190,7 +190,8 @@
                         <span class="field__label">Biome</span>
                         <span class="field__select-shell">
                             <select id="biome-select" class="field__input">
-                                <option value="normal">Normal</option>
+                                <option value="roe">ROE</option>
+                                <option value="normal" selected>Normal</option>
                                 <option value="day">Day</option>
                                 <option value="night">Night</option>
                                 <option value="rainy">Rainy</option>

--- a/script.js
+++ b/script.js
@@ -170,6 +170,21 @@ const auras = [
 
 const cutscenePriority = ["equinox-cs", "lumi-cs", "pixelation-cs", "dreammetric-cs", "oppression-cs"];
 
+const ROE_EXCLUDED_AURAS = new Set([
+    "Dreammetric - 520,000,000",
+    "Oppression - 220,000,000",
+    "Glitch - 12,210,110",
+    "★★★ - 10,000",
+    "★★ - 1,000",
+    "★ - 100"
+]);
+
+const ROE_BREAKTHROUGH_EXCLUSIONS = new Set([
+    "Twilight : Withering Grace - 180,000,000",
+    "Aegis : Watergun - 825,000,000",
+    "Manta - 300,000,000"
+]);
+
 auras.forEach(aura => {
     aura.wonCount = 0;
 });
@@ -241,20 +256,27 @@ function roll() {
             return aura;
         }).sort((a, b) => b.effectiveChance - a.effectiveChance);
     } else {
+        const isRoe = biome === "roe";
+        const glitchLikeBiome = biome === "glitch" || isRoe;
+        const exclusivityBiome = isRoe ? "glitch" : biome;
         effectiveAuras = auras.map(aura => {
+            if (isRoe && ROE_EXCLUDED_AURAS.has(aura.name)) {
+                aura.effectiveChance = Infinity;
+                return aura;
+            }
             if (aura.exclusiveTo) {
                 if (aura.exclusiveTo.includes("limbo") && !aura.exclusiveTo.includes("limbo-null")) {
                     aura.effectiveChance = Infinity;
                     return aura;
                 }
-                if (!aura.exclusiveTo.includes("limbo-null") && !aura.exclusiveTo.includes(biome)) {
+                if (!aura.exclusiveTo.includes("limbo-null") && !aura.exclusiveTo.includes(exclusivityBiome)) {
                     aura.effectiveChance = Infinity;
                     return aura;
                 }
             }
             let effectiveChance = aura.chance;
             if (aura.breakthrough) {
-                if (biome === "glitch") {
+                if (glitchLikeBiome && (!isRoe || !ROE_BREAKTHROUGH_EXCLUSIONS.has(aura.name))) {
                     let minChance = aura.chance;
                     for (const mult of Object.values(aura.breakthrough)) {
                         minChance = Math.min(minChance, Math.floor(aura.chance / mult));


### PR DESCRIPTION
## Summary
- add the ROE biome option to the selector with normal ambience
- treat ROE as a glitch-like biome while excluding specified auras and keeping select breakthroughs at full rarity
- ensure biome assets map supports the new option without altering existing defaults

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de23648c808321bbb1ae66caf6a9e5