### PR TITLE
Adjust biome select arrow spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -188,7 +188,7 @@
                     </label>
                     <label class="field field--select" for="biome-select">
                         <span class="field__label">Biome</span>
-                        <span class="field__select-shell">
+                        <span class="field__select-shell field__select-shell--biome">
                             <select id="biome-select" class="field__input">
                                 <option value="roe">Rune of Everything</option>
                                 <option value="normal" selected>Normal</option>

--- a/style.css
+++ b/style.css
@@ -538,6 +538,10 @@ body {
     width: 160px;
 }
 
+.field__select-shell--biome {
+    width: clamp(210px, 24vw, 280px);
+}
+
 .field--select select.field__input {
     appearance: none;
     -webkit-appearance: none;
@@ -559,6 +563,10 @@ body {
     transform: translateY(-50%) rotate(45deg);
     pointer-events: none;
     transition: border-color 0.2s ease, transform 0.2s ease;
+}
+
+#biome-select.field__input {
+    padding-right: 60px;
 }
 
 .field--select:focus-within .field__select-shell::after {


### PR DESCRIPTION
## Summary
- widen the biome select shell to give the dropdown arrow breathing room
- increase biome select padding so the arrow no longer overlaps text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de26ad98788321849b633d59b334b1