### PR TITLE
Fix luck probability calculation

### DIFF
--- a/script.js
+++ b/script.js
@@ -222,6 +222,7 @@ function roll() {
     }
 
     const total = parseInt(document.getElementById('rolls').value);
+    const luckValue = Math.max(0, Number.parseFloat(luck.value) || 0);
     const biome = document.getElementById('biome-select').value;
     
     results.innerHTML = `Rolling...`;
@@ -305,7 +306,8 @@ function roll() {
                 let usedBT = aura.effectiveChance !== aura.chance;
                 let btChance = usedBT ? aura.effectiveChance : null;
                 
-                if (Random(1, Math.floor(chance / luck.value)) === 1) {
+                const successThreshold = Math.min(chance, luckValue);
+                if (successThreshold > 0 && Random(1, chance) <= successThreshold) {
                     aura.wonCount++;
                     if (usedBT) {
                         if (!btAuras[aura.name]) {


### PR DESCRIPTION
## Summary
- parse the luck input once per roll and clamp it to non-negative values
- compare each aura roll against the exact luck threshold instead of dividing chance by luck

## Testing
- node - <<'NODE' # simulated probabilities

------
https://chatgpt.com/codex/tasks/task_e_68de470ca32c83219293ce101327be41