### PR TITLE
Add seasonal aura outline styling

### DIFF
--- a/func.js
+++ b/func.js
@@ -652,12 +652,53 @@ function getRarityClass(aura, biome) {
     return 'rarity-basic';
 }
 
+const auraOutlineOverrides = new Map([
+    ['Prowler', 'aura-outline-prowler'],
+    ['Divinus : Love', 'aura-outline-valentine'],
+    ['Flushed : Heart Eye', 'aura-outline-valentine'],
+    ['Pukeko', 'aura-outline-april'],
+    ['Flushed : Troll', 'aura-outline-april'],
+    ['Undefined : Defined', 'aura-outline-april'],
+    ['Origin : Onion', 'aura-outline-april'],
+    ['Chromatic : Kromat1k', 'aura-outline-april'],
+    ['Glock : the glock of the sky', 'aura-outline-april'],
+    ["Impeached : I'm Peach", 'aura-outline-april'],
+    ['Star Rider : Starfish Rider', 'aura-outline-summer'],
+    ['Watermelon', 'aura-outline-summer'],
+    ['Surfer : Shard Surfer', 'aura-outline-summer'],
+    ['Manta', 'aura-outline-summer'],
+    ['Aegis : Watergun', 'aura-outline-summer'],
+    ['Innovator', 'aura-outline-innovator'],
+    ['Wonderland', 'aura-outline-winter'],
+    ['Santa Frost', 'aura-outline-winter'],
+    ['Winter Fantasy', 'aura-outline-winter'],
+    ['Express', 'aura-outline-winter'],
+    ['Abominable', 'aura-outline-winter'],
+    ['Atlas : Yuletide', 'aura-outline-winter'],
+]);
+
 function getAuraStyleClass(aura) {
     if (!aura) return '';
+
     const name = typeof aura === 'string' ? aura : aura.name;
     if (!name) return '';
-    if (name.startsWith('Pixelation')) return 'aura-effect-pixelation';
-    if (name.startsWith('Luminosity')) return 'aura-effect-luminosity';
-    if (name.startsWith('Equinox')) return 'aura-effect-equinox';
-    return '';
+
+    const classes = [];
+    if (name.startsWith('Pixelation')) classes.push('aura-effect-pixelation');
+    if (name.startsWith('Luminosity')) classes.push('aura-effect-luminosity');
+    if (name.startsWith('Equinox')) classes.push('aura-effect-equinox');
+
+    const auraData = typeof aura === 'string' ? null : aura;
+    const exclusiveTo = auraData && Array.isArray(auraData.exclusiveTo) ? auraData.exclusiveTo : null;
+    if (exclusiveTo && exclusiveTo.some((zone) => zone === 'pumpkinMoon' || zone === 'graveyard')) {
+        classes.push('aura-outline-halloween');
+    }
+
+    const shortName = name.includes(' - ') ? name.split(' - ')[0].trim() : name.trim();
+    const overrideClass = auraOutlineOverrides.get(shortName);
+    if (overrideClass) {
+        classes.push(overrideClass);
+    }
+
+    return classes.join(' ');
 }

--- a/style.css
+++ b/style.css
@@ -846,6 +846,77 @@ select.field__input option {
 .rarity-challenged { color: #000000; text-shadow: -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff; }
 .rarity-limbo { color: #000; text-shadow: 0 0 2px #aaa, 0 0 4px #aaa, 1px 1px 0 #aaa, -1px -1px 0 #aaa; }
 
+.aura-outline-halloween {
+    text-shadow:
+        0 0 4px rgba(255, 140, 0, 0.85),
+        0 0 8px rgba(255, 90, 0, 0.7),
+        1px 1px 0 rgba(60, 20, 0, 0.95),
+        -1px 1px 0 rgba(60, 20, 0, 0.95),
+        1px -1px 0 rgba(60, 20, 0, 0.95),
+        -1px -1px 0 rgba(60, 20, 0, 0.95);
+}
+
+.aura-outline-prowler {
+    text-shadow:
+        0 0 4px rgba(80, 170, 255, 0.85),
+        0 0 8px rgba(20, 110, 220, 0.7),
+        1px 1px 0 rgba(5, 40, 120, 0.9),
+        -1px 1px 0 rgba(5, 40, 120, 0.9),
+        1px -1px 0 rgba(5, 40, 120, 0.9),
+        -1px -1px 0 rgba(5, 40, 120, 0.9);
+}
+
+.aura-outline-valentine {
+    text-shadow:
+        0 0 4px rgba(255, 140, 200, 0.85),
+        0 0 8px rgba(255, 95, 170, 0.75),
+        1px 1px 0 rgba(115, 20, 80, 0.9),
+        -1px 1px 0 rgba(115, 20, 80, 0.9),
+        1px -1px 0 rgba(115, 20, 80, 0.9),
+        -1px -1px 0 rgba(115, 20, 80, 0.9);
+}
+
+.aura-outline-april {
+    text-shadow:
+        0 0 4px rgba(190, 190, 190, 0.85),
+        0 0 8px rgba(140, 140, 140, 0.75),
+        1px 1px 0 rgba(80, 80, 80, 0.9),
+        -1px 1px 0 rgba(80, 80, 80, 0.9),
+        1px -1px 0 rgba(80, 80, 80, 0.9),
+        -1px -1px 0 rgba(80, 80, 80, 0.9);
+}
+
+.aura-outline-summer {
+    text-shadow:
+        0 0 4px rgba(140, 230, 255, 0.9),
+        0 0 8px rgba(70, 190, 240, 0.75),
+        1px 1px 0 rgba(10, 95, 155, 0.85),
+        -1px 1px 0 rgba(10, 95, 155, 0.85),
+        1px -1px 0 rgba(10, 95, 155, 0.85),
+        -1px -1px 0 rgba(10, 95, 155, 0.85);
+}
+
+.aura-outline-innovator {
+    color: #f1e6ff;
+    text-shadow:
+        0 0 4px rgba(200, 140, 255, 0.9),
+        0 0 8px rgba(150, 90, 235, 0.75),
+        1px 1px 0 rgba(70, 20, 120, 0.9),
+        -1px 1px 0 rgba(70, 20, 120, 0.9),
+        1px -1px 0 rgba(70, 20, 120, 0.9),
+        -1px -1px 0 rgba(70, 20, 120, 0.9);
+}
+
+.aura-outline-winter {
+    text-shadow:
+        0 0 4px rgba(210, 240, 255, 0.9),
+        0 0 8px rgba(140, 200, 255, 0.75),
+        1px 1px 0 rgba(40, 90, 140, 0.85),
+        -1px 1px 0 rgba(40, 90, 140, 0.85),
+        1px -1px 0 rgba(40, 90, 140, 0.85),
+        -1px -1px 0 rgba(40, 90, 140, 0.85);
+}
+
 .aura-effect-pixelation,
 .aura-effect-luminosity,
 .aura-effect-equinox {


### PR DESCRIPTION
## Summary
- add a mapping that assigns event outline classes to the specified auras and biomes
- define CSS for the new aura outline themes covering halloween, prowler, valentine, april fools, summer, innovator, and winter events

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de66ed66948321b6a2eb0039847dad