### PR TITLE
Ensure event aura text ignores rarity colors

### DIFF
--- a/func.js
+++ b/func.js
@@ -661,7 +661,7 @@ const auraOutlineOverrides = new Map([
     ['Undefined : Defined', 'aura-outline-april'],
     ['Origin : Onion', 'aura-outline-april'],
     ['Chromatic : Kromat1k', 'aura-outline-april'],
-    ['Glock : the glock of the sky', 'aura-outline-april'],
+    ['Glock : Glock of the sky', 'aura-outline-april'],
     ["Impeached : I'm Peach", 'aura-outline-april'],
     ['Star Rider : Starfish Rider', 'aura-outline-summer'],
     ['Watermelon', 'aura-outline-summer'],

--- a/index.html
+++ b/index.html
@@ -186,32 +186,74 @@
                             <button class="ui-button ui-button--minor" type="button" onclick="resetRolls()">Reset</button>
                         </div>
                     </label>
-                    <label class="field field--select" for="biome-select">
-                        <span class="field__label">Biome</span>
-                        <span class="field__select-shell field__select-shell--biome">
-                            <select id="biome-select" class="field__input">
-                                <option value="roe">Rune of Everything</option>
-                                <option value="normal" selected>Normal</option>
-                                <option value="day">Day</option>
-                                <option value="night">Night</option>
-                                <option value="rainy">Rainy</option>
-                                <option value="windy">Windy</option>
-                                <option value="snowy">Snowy</option>
-                                <option value="sandstorm">Sandstorm</option>
-                                <option value="hell">Hell</option>
-                                <option value="starfall">Starfall</option>
-                                <option value="corruption">Corruption</option>
-                                <option value="null">NULL</option>
-                                <option value="dreamspace">Dreamspace</option>
-                                <option value="glitch">Glitch</option>
-                                <option value="limbo">LIMBO</option>
-                                <option value="blazing">Blazing Sun</option>
-                                <option value="anotherRealm">Another Realm</option>
-                                <option value="graveyard">Graveyard</option>
-                                <option value="pumpkinMoon">Pumpkin Moon</option>
-                            </select>
-                        </span>
-                    </label>
+                    <div class="biome-control-row">
+                        <label class="field field--select" for="biome-select">
+                            <span class="field__label">Biome</span>
+                            <span class="field__select-shell field__select-shell--biome">
+                                <select id="biome-select" class="field__input">
+                                    <option value="roe">Rune of Everything</option>
+                                    <option value="normal" selected>Normal</option>
+                                    <option value="day">Day</option>
+                                    <option value="night">Night</option>
+                                    <option value="rainy">Rainy</option>
+                                    <option value="windy">Windy</option>
+                                    <option value="snowy">Snowy</option>
+                                    <option value="sandstorm">Sandstorm</option>
+                                    <option value="hell">Hell</option>
+                                    <option value="starfall">Starfall</option>
+                                    <option value="corruption">Corruption</option>
+                                    <option value="null">NULL</option>
+                                    <option value="dreamspace">Dreamspace</option>
+                                    <option value="glitch">Glitch</option>
+                                    <option value="limbo">LIMBO</option>
+                                    <option value="blazing">Blazing Sun</option>
+                                    <option value="anotherRealm">Another Realm</option>
+                                    <option value="graveyard">Graveyard</option>
+                                    <option value="pumpkinMoon">Pumpkin Moon</option>
+                                </select>
+                            </span>
+                        </label>
+                        <div class="field field--events">
+                            <span class="field__label">Events</span>
+                            <details class="event-select" id="event-select">
+                                <summary id="event-summary" class="field__input field__input--event field__input--placeholder" role="button" aria-expanded="false">No events enabled</summary>
+                                <div class="event-select__menu" id="event-menu" role="listbox" aria-multiselectable="true">
+                                    <label class="event-select__option">
+                                        <input type="checkbox" value="valentine2024" data-event-id="valentine2024">
+                                        <span>Valentine 2024</span>
+                                    </label>
+                                    <label class="event-select__option">
+                                        <input type="checkbox" value="aprilFools2024" data-event-id="aprilFools2024">
+                                        <span>April Fools 2024</span>
+                                    </label>
+                                    <label class="event-select__option">
+                                        <input type="checkbox" value="summer2024" data-event-id="summer2024">
+                                        <span>Summer 2024</span>
+                                    </label>
+                                    <label class="event-select__option">
+                                        <input type="checkbox" value="ria2024" data-event-id="ria2024">
+                                        <span>RIA Event 2024</span>
+                                    </label>
+                                    <label class="event-select__option">
+                                        <input type="checkbox" value="halloween2024" data-event-id="halloween2024">
+                                        <span>Halloween 2024</span>
+                                    </label>
+                                    <label class="event-select__option">
+                                        <input type="checkbox" value="winter2024" data-event-id="winter2024">
+                                        <span>Winter 2024</span>
+                                    </label>
+                                    <label class="event-select__option">
+                                        <input type="checkbox" value="aprilFools2025" data-event-id="aprilFools2025">
+                                        <span>April Fools 2025</span>
+                                    </label>
+                                    <label class="event-select__option">
+                                        <input type="checkbox" value="summer2025" data-event-id="summer2025">
+                                        <span>Summer 2025</span>
+                                    </label>
+                                </div>
+                            </details>
+                        </div>
+                    </div>
                     <div class="quick-actions">
                         <button class="ui-button ui-button--ghost" type="button" onclick="setGlitch()">Set Glitch</button>
                         <button class="ui-button ui-button--ghost" type="button" onclick="setLimbo()">Set Limbo</button>

--- a/script.js
+++ b/script.js
@@ -45,7 +45,7 @@ const auras = [
     { name: "Nightmare Sky - 190,000,000", chance: 190000000, exclusiveTo: ["pumpkinMoon"] },
     { name: "Twilight : Withering Grace - 180,000,000", chance: 180000000, breakthrough: { night: 10 } },
     { name: "Symphony - 175,000,000", chance: 175000000 },
-    { name: "Glock : the glock of the sky - 170,000,000", chance: 170000000, breakthrough: { night: 10 } },
+    { name: "Glock : Glock of the sky - 170,000,000", chance: 170000000, breakthrough: { night: 10 } },
     { name: "Overture - 150,000,000", chance: 150000000 },
     { name: "Abominable - 120,000,000", chance: 120000000, breakthrough: { snowy: 3 } },
     { name: "Starscourge : Radiant - 100,000,000", chance: 100000000, breakthrough: { starfall: 5 } },
@@ -198,6 +198,82 @@ const auras = [
     { name: "Nothing - 1", chance: 1, exclusiveTo: ["limbo"] },
 ];
 
+const EVENT_DEFINITIONS = [
+    { id: "valentine2024", label: "Valentine 2024" },
+    { id: "aprilFools2024", label: "April Fools 2024" },
+    { id: "summer2024", label: "Summer 2024" },
+    { id: "ria2024", label: "RIA Event 2024" },
+    { id: "halloween2024", label: "Halloween 2024" },
+    { id: "winter2024", label: "Winter 2024" },
+    { id: "aprilFools2025", label: "April Fools 2025" },
+    { id: "summer2025", label: "Summer 2025" },
+];
+
+const EVENT_AURA_MAP = {
+    valentine2024: [
+        "Divinus : Love - 32",
+        "Flushed : Heart Eye - 6,900",
+    ],
+    aprilFools2024: [
+        "Undefined : Defined - 2,222,000",
+        "Chromatic : Kromat1k - 40,000,000",
+        "Impeached : I'm Peach - 400,000,000",
+    ],
+    summer2024: [
+        "Star Rider : Starfish Rider - 250,000",
+        "Watermelon - 320,000",
+        "Surfer : Shard Surfer - 225,000,000",
+    ],
+    ria2024: [
+        "Innovator - 30,000,000",
+    ],
+    halloween2024: [
+        "Apostolos : Veil - 800,000,000",
+        "Harvester - 666,000,000",
+        "Nightmare Sky - 190,000,000",
+        "Dullahan - 72,000,000",
+        "Soul Hunter - 40,000,000",
+        "Cryptfire - 21,000,000",
+        "Moonflower - 10,000,000",
+        "Vital - 6,000,000",
+        "Lunar : Nightfall - 3,000,000",
+        "Pump - 200,000",
+    ],
+    winter2024: [
+        "Atlas : Yuletide - 510,000,000",
+        "Abominable - 120,000,000",
+        "Express - 90,000,000",
+        "Winter Fantasy - 72,000,000",
+        "Santa Frost - 45,000,000",
+        "Wonderland - 12,000,000",
+    ],
+    aprilFools2025: [
+        "Glock : Glock of the sky - 170,000,000",
+        "Origin : Onion - 8,000,000",
+        "Flushed : Troll - 1,000,000",
+        "Pukeko - 3,198",
+    ],
+    summer2025: [
+        "Aegis : Watergun - 825,000,000",
+        "Manta - 300,000,000",
+    ],
+};
+
+const BIOME_EVENT_REQUIREMENTS = {
+    graveyard: "halloween2024",
+    pumpkinMoon: "halloween2024",
+    blazing: "summer2025",
+};
+
+const activeEvents = new Set();
+const auraEventLookup = new Map();
+
+for (const [eventId, auraNames] of Object.entries(EVENT_AURA_MAP)) {
+    auraNames.forEach(name => {
+        auraEventLookup.set(name, eventId);
+    });
+}
+
 const cutscenePriority = ["equinox-cs", "lumi-cs", "pixelation-cs", "dreammetric-cs", "oppression-cs"];
 
 const ROE_EXCLUDED_AURAS = new Set([
@@ -228,7 +304,156 @@ const ROE_BREAKTHROUGH_EXCLUSIONS = new Set([
 
 auras.forEach(aura => {
     aura.wonCount = 0;
+    const eventId = auraEventLookup.get(aura.name);
+    if (eventId) {
+        aura.event = eventId;
+    }
 });
+
+const EVENT_SUMMARY_NONE = "No events enabled";
+
+function getActiveEventLabels() {
+    return EVENT_DEFINITIONS
+        .filter(event => activeEvents.has(event.id))
+        .map(event => event.label);
+}
+
+function updateEventSummary() {
+    const summary = document.getElementById('event-summary');
+    if (!summary) return;
+
+    const labels = getActiveEventLabels();
+    let displayText = EVENT_SUMMARY_NONE;
+
+    if (labels.length === 0) {
+        summary.classList.add('field__input--placeholder');
+    } else {
+        summary.classList.remove('field__input--placeholder');
+        if (labels.length === 1) {
+            displayText = labels[0];
+        } else if (labels.length === 2) {
+            displayText = `${labels[0]}, ${labels[1]}`;
+        } else {
+            displayText = `${labels[0]}, ${labels[1]} +${labels.length - 2} more`;
+        }
+    }
+
+    summary.textContent = displayText;
+    summary.title = labels.length > 0 ? labels.join(', ') : EVENT_SUMMARY_NONE;
+
+    const details = document.getElementById('event-select');
+    const isOpen = !!(details && details.open);
+    summary.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+}
+
+function applyEventBiomeRestrictions() {
+    const biomeSelect = document.getElementById('biome-select');
+    if (!biomeSelect) return;
+
+    const currentValue = biomeSelect.value;
+    let resetToDefault = false;
+
+    Array.from(biomeSelect.options).forEach(option => {
+        const requiredEvent = BIOME_EVENT_REQUIREMENTS[option.value];
+        if (!requiredEvent) {
+            option.disabled = false;
+            option.removeAttribute('title');
+            return;
+        }
+        const enabled = activeEvents.has(requiredEvent);
+        option.disabled = !enabled;
+        const eventLabel = EVENT_DEFINITIONS.find(event => event.id === requiredEvent)?.label;
+        if (!enabled && eventLabel) {
+            option.title = `${eventLabel} must be enabled to access this biome.`;
+        } else {
+            option.removeAttribute('title');
+        }
+        if (!enabled && option.value === currentValue) {
+            resetToDefault = true;
+        }
+    });
+
+    if (resetToDefault) {
+        biomeSelect.value = 'normal';
+        if (typeof handleBiomeUI === 'function') {
+            handleBiomeUI();
+        }
+    }
+}
+
+function setEventActive(eventId, enabled) {
+    if (!eventId) return;
+    const hasEvent = activeEvents.has(eventId);
+    if (enabled && !hasEvent) {
+        activeEvents.add(eventId);
+    } else if (!enabled && hasEvent) {
+        activeEvents.delete(eventId);
+    } else {
+        return;
+    }
+
+    const eventMenu = document.getElementById('event-menu');
+    if (eventMenu) {
+        const checkbox = eventMenu.querySelector(`input[type="checkbox"][data-event-id="${eventId}"]`);
+        if (checkbox && checkbox.checked !== enabled) {
+            checkbox.checked = enabled;
+        }
+    }
+
+    updateEventSummary();
+    applyEventBiomeRestrictions();
+}
+
+function initializeEventSelectors() {
+    const eventMenu = document.getElementById('event-menu');
+    if (!eventMenu) return;
+
+    const checkboxes = eventMenu.querySelectorAll('input[type="checkbox"][data-event-id]');
+    checkboxes.forEach(input => {
+        const eventId = input.dataset.eventId;
+        input.checked = activeEvents.has(eventId);
+        input.addEventListener('change', () => {
+            setEventActive(eventId, input.checked);
+        });
+    });
+
+    const details = document.getElementById('event-select');
+    if (details) {
+        details.addEventListener('toggle', () => {
+            const summary = document.getElementById('event-summary');
+            if (summary) {
+                summary.setAttribute('aria-expanded', details.open ? 'true' : 'false');
+            }
+        });
+    }
+
+    document.addEventListener('click', event => {
+        const detailsEl = document.getElementById('event-select');
+        if (!detailsEl || !detailsEl.open) return;
+        if (!detailsEl.contains(event.target)) {
+            detailsEl.open = false;
+            updateEventSummary();
+        }
+    });
+
+    document.addEventListener('keydown', event => {
+        if (event.key !== 'Escape') return;
+        const detailsEl = document.getElementById('event-select');
+        if (detailsEl && detailsEl.open) {
+            detailsEl.open = false;
+            const summary = document.getElementById('event-summary');
+            if (summary) {
+                summary.focus();
+            }
+            updateEventSummary();
+        }
+    });
+
+    updateEventSummary();
+    applyEventBiomeRestrictions();
+}
+
+document.addEventListener('DOMContentLoaded', initializeEventSelectors);
 
 // xp
 function getXpForChance(chance) {
@@ -265,6 +490,8 @@ function roll() {
     const total = parseInt(document.getElementById('rolls').value);
     const luckValue = Math.max(0, Number.parseFloat(luck.value) || 0);
     const biome = document.getElementById('biome-select').value;
+    const activeEventSnapshot = new Set(activeEvents);
+    const isEventAuraEnabled = aura => !aura.event || activeEventSnapshot.has(aura.event);
     
     results.innerHTML = `Rolling...`;
     let rolls = 0;
@@ -287,6 +514,7 @@ function roll() {
     let effectiveAuras;
     if (biome === "limbo") {
         effectiveAuras = auras.filter(aura =>
+            isEventAuraEnabled(aura) &&
             aura.exclusiveTo && (aura.exclusiveTo.includes("limbo") || aura.exclusiveTo.includes("limbo-null"))
         ).map(aura => {
             let effectiveChance = aura.chance;
@@ -302,6 +530,10 @@ function roll() {
         const glitchLikeBiome = biome === "glitch" || isRoe;
         const exclusivityBiome = isRoe ? "glitch" : biome;
         effectiveAuras = auras.map(aura => {
+            if (!isEventAuraEnabled(aura)) {
+                aura.effectiveChance = Infinity;
+                return aura;
+            }
             if (isRoe && ROE_EXCLUDED_AURAS.has(aura.name)) {
                 aura.effectiveChance = Infinity;
                 return aura;
@@ -431,7 +663,8 @@ function roll() {
                 if (aura.wonCount > 0) {
                     let rarityClass = getRarityClass(aura, biome);
                     let specialClass = getAuraStyleClass(aura);
-                    let classAttr = [rarityClass, specialClass].filter(Boolean).join(' ');
+                    let eventClass = aura.event ? 'aura-event-text' : '';
+                    let classAttr = [rarityClass, specialClass, eventClass].filter(Boolean).join(' ');
                     if (btAuras[aura.name]) {
                         let btName = aura.name.replace(
                             /-\s*[\d,]+/,

--- a/style.css
+++ b/style.css
@@ -542,6 +542,153 @@ body {
     width: clamp(210px, 24vw, 225px);
 }
 
+.biome-control-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: flex-end;
+}
+
+.biome-control-row > .field {
+    flex: 1 1 clamp(210px, 24vw, 240px);
+}
+
+.field--events {
+    min-width: clamp(200px, 25vw, 240px);
+}
+
+.event-select {
+    position: relative;
+    display: block;
+}
+
+.field__input--event {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    cursor: pointer;
+    user-select: none;
+}
+
+.field__input--event.field__input--placeholder {
+    color: var(--text-tertiary);
+}
+
+.event-select summary {
+    list-style: none;
+    position: relative;
+    padding-right: 48px;
+}
+
+.event-select summary::-webkit-details-marker {
+    display: none;
+}
+
+.event-select summary::after {
+    content: '';
+    position: absolute;
+    top: 50%;
+    right: 18px;
+    width: 10px;
+    height: 10px;
+    border-right: 2px solid var(--accent);
+    border-bottom: 2px solid var(--accent);
+    transform: translateY(-50%) rotate(45deg);
+    transition: transform 0.2s ease, border-color 0.2s ease;
+    pointer-events: none;
+}
+
+.event-select summary:hover,
+.event-select summary:focus-visible {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 2px rgba(127, 227, 255, 0.25);
+    outline: none;
+}
+
+.event-select[open] summary::after {
+    transform: translateY(-50%) rotate(225deg);
+}
+
+.event-select__menu {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    right: 0;
+    background: linear-gradient(175deg, rgba(12, 20, 38, 0.96), rgba(4, 10, 22, 0.98));
+    border: 1px solid rgba(95, 160, 230, 0.35);
+    border-radius: 12px;
+    box-shadow: 0 18px 38px rgba(4, 10, 24, 0.65);
+    padding: 14px 16px;
+    display: grid;
+    gap: 10px;
+    max-height: 320px;
+    overflow-y: auto;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity 0.2s ease, transform 0.2s ease;
+    z-index: 20;
+}
+
+.event-select[open] .event-select__menu {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+}
+
+.event-select__option {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    font-size: 13px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+.event-select__option:hover {
+    color: var(--text-primary);
+}
+
+.event-select__option input[type="checkbox"] {
+    appearance: none;
+    width: 18px;
+    height: 18px;
+    border-radius: 5px;
+    border: 1px solid rgba(95, 160, 230, 0.5);
+    background: rgba(6, 12, 24, 0.85);
+    display: grid;
+    place-items: center;
+    transition: border-color 0.2s ease, background-color 0.2s ease;
+}
+
+.event-select__option input[type="checkbox"]::after {
+    content: '';
+    width: 10px;
+    height: 10px;
+    clip-path: polygon(14% 44%, 0% 63%, 43% 100%, 100% 18%, 80% 0%, 40% 62%);
+    background: transparent;
+    transition: background 0.2s ease;
+}
+
+.event-select__option input[type="checkbox"]:checked {
+    border-color: var(--accent);
+    background: rgba(20, 36, 64, 0.95);
+}
+
+.event-select__option input[type="checkbox"]:checked::after {
+    background: var(--accent);
+}
+
+.event-select__option input[type="checkbox"]:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.event-select__option span {
+    flex: 1;
+}
+
 .field--select select.field__input {
     appearance: none;
     -webkit-appearance: none;
@@ -799,6 +946,16 @@ select.field__input option {
     .resource-card--nolifers:focus-visible .resource-card__arrow-cluster {
         transform: translateY(-50%) scale(0.9);
     }
+
+    .biome-control-row {
+        gap: 12px;
+    }
+
+    .biome-control-row > .field,
+    .field--events {
+        flex: 1 1 100%;
+        min-width: 100%;
+    }
 }
 
 .video-overlay {
@@ -845,6 +1002,11 @@ select.field__input option {
 .rarity-transcendent { color: #afeeee; text-shadow: 1px 1px 2px #000; }
 .rarity-challenged { color: #000000; text-shadow: -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff; }
 .rarity-limbo { color: #000; text-shadow: 0 0 2px #aaa, 0 0 4px #aaa, 1px 1px 0 #aaa, -1px -1px 0 #aaa; }
+
+.aura-event-text {
+  color: #fff !important;
+  text-shadow: 1px 1px 2px #000;
+}
 
 .aura-outline-halloween {
     text-shadow:


### PR DESCRIPTION
## Summary
- add an event text class to aura results so seasonal drops override their rarity color
- style the new event aura class with white text to let outline colors define the event look

## Testing
- Not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68de6ae739b483218aa5a8b9d337af74