### PR TITLE
Add upward-opening custom dropdown menus

### DIFF
--- a/func.js
+++ b/func.js
@@ -335,7 +335,11 @@ function setLuck(value) {
     lastDaveMultiplier = 1;
     document.getElementById('vip-select').value = "1";
     document.getElementById('xyz-luck').checked = false;
-    if (document.getElementById('dave-luck-select')) document.getElementById('dave-luck-select').value = "1";
+    refreshCustomSelect('vip-select');
+    if (document.getElementById('dave-luck-select')) {
+        document.getElementById('dave-luck-select').value = "1";
+        refreshCustomSelect('dave-luck-select');
+    }
     document.getElementById('luck').value = value;
 }
 
@@ -358,7 +362,11 @@ function updateLuckValue() {
         lastDaveMultiplier = 1;
         document.getElementById('vip-select').value = "1";
         document.getElementById('xyz-luck').checked = false;
-        if (document.getElementById('dave-luck-select')) document.getElementById('dave-luck-select').value = "1";
+        refreshCustomSelect('vip-select');
+        if (document.getElementById('dave-luck-select')) {
+            document.getElementById('dave-luck-select').value = "1";
+            refreshCustomSelect('dave-luck-select');
+        }
         return;
     }
     currentLuck = baseLuck * vipMultiplier * xyzMultiplier * daveMultiplier;
@@ -409,7 +417,6 @@ function handleBiomeUI() {
     const xyzLuckContainer = document.getElementById('xyz-luck-container');
     const luckPresets = document.getElementById('luck-presets');
     const voidHeartBtn = document.getElementById('void-heart-btn');
-    const vipSelect = document.getElementById('vip-select');
     if (biome === "limbo") {
         if (daveLuckContainer) daveLuckContainer.style.display = "";
         if (xyzLuckContainer) xyzLuckContainer.style.display = "none";
@@ -439,6 +446,7 @@ function handleBiomeUI() {
     }
     applyBiomeTheme(biome);
     updateLuckValue();
+    refreshCustomSelect('biome-select');
 }
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -476,7 +484,11 @@ document.addEventListener('DOMContentLoaded', () => {
         lastDaveMultiplier = 1;
         document.getElementById('vip-select').value = "1";
         document.getElementById('xyz-luck').checked = false;
-        if (document.getElementById('dave-luck-select')) document.getElementById('dave-luck-select').value = "1";
+        refreshCustomSelect('vip-select');
+        if (document.getElementById('dave-luck-select')) {
+            document.getElementById('dave-luck-select').value = "1";
+            refreshCustomSelect('dave-luck-select');
+        }
     });
     document.getElementById('biome-select').addEventListener('change', handleBiomeUI);
     handleBiomeUI();

--- a/index.html
+++ b/index.html
@@ -131,17 +131,21 @@
                     <label class="field field--select" for="vip-select">
                         <span class="field__label">VIP Luck</span>
                         <span class="field__select-shell">
-                            <select id="vip-select" class="field__input">
+                            <select id="vip-select" class="field__input field__input--native">
                                 <option value="1">None</option>
                                 <option value="1.2">VIP or VIP+</option>
                                 <option value="1.3">VIP and VIP+</option>
                             </select>
+                            <details class="ui-select ui-select--single" data-select="vip-select">
+                                <summary class="field__input ui-select__summary" role="button" aria-haspopup="listbox" aria-expanded="false">None</summary>
+                                <div class="ui-select__menu" role="listbox"></div>
+                            </details>
                         </span>
                     </label>
                     <div id="dave-luck-container" class="field field--select" style="display:none;">
                         <label class="field__label" for="dave-luck-select">Dave's Luck</label>
                         <span class="field__select-shell">
-                            <select id="dave-luck-select" class="field__input">
+                            <select id="dave-luck-select" class="field__input field__input--native">
                                 <option value="1">None</option>
                                 <option value="1.2">Dave's Luck 1</option>
                                 <option value="1.4">Dave's Luck 2</option>
@@ -149,6 +153,10 @@
                                 <option value="1.8">Dave's Luck 4</option>
                                 <option value="2">Dave's Luck 5</option>
                             </select>
+                            <details class="ui-select ui-select--single" data-select="dave-luck-select">
+                                <summary class="field__input ui-select__summary" role="button" aria-haspopup="listbox" aria-expanded="false">None</summary>
+                                <div class="ui-select__menu" role="listbox"></div>
+                            </details>
                         </span>
                     </div>
                     <div id="xyz-luck-container" class="field field--switch">
@@ -190,7 +198,7 @@
                         <label class="field field--select" for="biome-select">
                             <span class="field__label">Biome</span>
                             <span class="field__select-shell field__select-shell--biome">
-                                <select id="biome-select" class="field__input">
+                                <select id="biome-select" class="field__input field__input--native">
                                     <option value="roe">Rune of Everything</option>
                                     <option value="normal" selected>Normal</option>
                                     <option value="day">Day</option>
@@ -211,42 +219,46 @@
                                     <option value="graveyard">Graveyard</option>
                                     <option value="pumpkinMoon">Pumpkin Moon</option>
                                 </select>
+                                <details class="ui-select ui-select--single" data-select="biome-select">
+                                    <summary class="field__input ui-select__summary" role="button" aria-haspopup="listbox" aria-expanded="false">Normal</summary>
+                                    <div class="ui-select__menu" role="listbox"></div>
+                                </details>
                             </span>
                         </label>
                         <div class="field field--events">
                             <span class="field__label">Events</span>
-                            <details class="event-select" id="event-select">
-                                <summary id="event-summary" class="field__input field__input--event field__input--placeholder" role="button" aria-expanded="false">No events enabled</summary>
-                                <div class="event-select__menu" id="event-menu" role="listbox" aria-multiselectable="true">
-                                    <label class="event-select__option">
+                            <details class="ui-select ui-select--multi" id="event-select" data-select="event-select">
+                                <summary id="event-summary" class="field__input field__input--event field__input--placeholder ui-select__summary" role="button" aria-expanded="false" aria-haspopup="listbox">No events enabled</summary>
+                                <div class="ui-select__menu" id="event-menu" role="listbox" aria-multiselectable="true">
+                                    <label class="ui-select__option ui-select__option--checkbox">
                                         <input type="checkbox" value="valentine2024" data-event-id="valentine2024">
                                         <span>Valentine 2024</span>
                                     </label>
-                                    <label class="event-select__option">
+                                    <label class="ui-select__option ui-select__option--checkbox">
                                         <input type="checkbox" value="aprilFools2024" data-event-id="aprilFools2024">
                                         <span>April Fools 2024</span>
                                     </label>
-                                    <label class="event-select__option">
+                                    <label class="ui-select__option ui-select__option--checkbox">
                                         <input type="checkbox" value="summer2024" data-event-id="summer2024">
                                         <span>Summer 2024</span>
                                     </label>
-                                    <label class="event-select__option">
+                                    <label class="ui-select__option ui-select__option--checkbox">
                                         <input type="checkbox" value="ria2024" data-event-id="ria2024">
                                         <span>RIA Event 2024</span>
                                     </label>
-                                    <label class="event-select__option">
+                                    <label class="ui-select__option ui-select__option--checkbox">
                                         <input type="checkbox" value="halloween2024" data-event-id="halloween2024">
                                         <span>Halloween 2024</span>
                                     </label>
-                                    <label class="event-select__option">
+                                    <label class="ui-select__option ui-select__option--checkbox">
                                         <input type="checkbox" value="winter2024" data-event-id="winter2024">
                                         <span>Winter 2024</span>
                                     </label>
-                                    <label class="event-select__option">
+                                    <label class="ui-select__option ui-select__option--checkbox">
                                         <input type="checkbox" value="aprilFools2025" data-event-id="aprilFools2025">
                                         <span>April Fools 2025</span>
                                     </label>
-                                    <label class="event-select__option">
+                                    <label class="ui-select__option ui-select__option--checkbox">
                                         <input type="checkbox" value="summer2025" data-event-id="summer2025">
                                         <span>Summer 2025</span>
                                     </label>

--- a/style.css
+++ b/style.css
@@ -532,6 +532,19 @@ body {
     position: relative;
 }
 
+.field__input--native {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    margin: -1px;
+    padding: 0;
+    border: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+}
+
 .field__select-shell {
     position: relative;
     display: block;
@@ -557,11 +570,12 @@ body {
     min-width: clamp(200px, 25vw, 240px);
 }
 
-.event-select {
+.ui-select {
     position: relative;
     display: block;
 }
 
+.ui-select__summary.field__input--event,
 .field__input--event {
     display: flex;
     align-items: center;
@@ -570,21 +584,22 @@ body {
     user-select: none;
 }
 
+.ui-select__summary.field__input--placeholder,
 .field__input--event.field__input--placeholder {
     color: var(--text-tertiary);
 }
 
-.event-select summary {
+.ui-select summary {
     list-style: none;
     position: relative;
     padding-right: 48px;
 }
 
-.event-select summary::-webkit-details-marker {
+.ui-select summary::-webkit-details-marker {
     display: none;
 }
 
-.event-select summary::after {
+.ui-select summary::after {
     content: '';
     position: absolute;
     top: 50%;
@@ -598,26 +613,26 @@ body {
     pointer-events: none;
 }
 
-.event-select summary:hover,
-.event-select summary:focus-visible {
+.ui-select summary:hover,
+.ui-select summary:focus-visible {
     border-color: var(--accent);
     box-shadow: 0 0 0 2px rgba(127, 227, 255, 0.25);
     outline: none;
 }
 
-.event-select[open] summary::after {
+.ui-select[open] summary::after {
     transform: translateY(-50%) rotate(225deg);
 }
 
-.event-select__menu {
+.ui-select__menu {
     position: absolute;
-    top: calc(100% + 8px);
+    bottom: calc(100% + 8px);
     left: 0;
     right: 0;
     background: linear-gradient(175deg, rgba(12, 20, 38, 0.96), rgba(4, 10, 22, 0.98));
     border: 1px solid rgba(95, 160, 230, 0.35);
     border-radius: 12px;
-    box-shadow: 0 18px 38px rgba(4, 10, 24, 0.65);
+    box-shadow: 0 -18px 38px rgba(4, 10, 24, 0.65);
     padding: 14px 16px;
     display: grid;
     gap: 10px;
@@ -625,18 +640,18 @@ body {
     overflow-y: auto;
     opacity: 0;
     pointer-events: none;
-    transform: translateY(-6px);
+    transform: translateY(6px);
     transition: opacity 0.2s ease, transform 0.2s ease;
     z-index: 20;
 }
 
-.event-select[open] .event-select__menu {
+.ui-select[open] .ui-select__menu {
     opacity: 1;
     pointer-events: auto;
     transform: translateY(0);
 }
 
-.event-select__option {
+.ui-select__option {
     display: flex;
     align-items: center;
     gap: 12px;
@@ -646,11 +661,11 @@ body {
     color: var(--text-secondary);
 }
 
-.event-select__option:hover {
+.ui-select__option:hover {
     color: var(--text-primary);
 }
 
-.event-select__option input[type="checkbox"] {
+.ui-select__option--checkbox input[type="checkbox"] {
     appearance: none;
     width: 18px;
     height: 18px;
@@ -662,7 +677,7 @@ body {
     transition: border-color 0.2s ease, background-color 0.2s ease;
 }
 
-.event-select__option input[type="checkbox"]::after {
+.ui-select__option--checkbox input[type="checkbox"]::after {
     content: '';
     width: 10px;
     height: 10px;
@@ -671,22 +686,60 @@ body {
     transition: background 0.2s ease;
 }
 
-.event-select__option input[type="checkbox"]:checked {
+.ui-select__option--checkbox input[type="checkbox"]:checked {
     border-color: var(--accent);
     background: rgba(20, 36, 64, 0.95);
 }
 
-.event-select__option input[type="checkbox"]:checked::after {
+.ui-select__option--checkbox input[type="checkbox"]:checked::after {
     background: var(--accent);
 }
 
-.event-select__option input[type="checkbox"]:focus-visible {
+.ui-select__option--checkbox input[type="checkbox"]:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
 }
 
-.event-select__option span {
+.ui-select__option span {
     flex: 1;
+}
+
+.ui-select--single .ui-select__menu {
+    gap: 6px;
+}
+
+.ui-select__option-button {
+    display: inline-flex;
+    align-items: center;
+    width: 100%;
+    padding: 10px 12px;
+    border: none;
+    border-radius: 8px;
+    background: transparent;
+    color: var(--text-secondary);
+    font-size: 13px;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    transition: color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.ui-select__option-button:hover,
+.ui-select__option-button:focus-visible {
+    color: var(--text-primary);
+    background: rgba(30, 60, 110, 0.2);
+    outline: none;
+}
+
+.ui-select__option-button--active {
+    background: rgba(20, 36, 64, 0.95);
+    color: var(--accent);
+    box-shadow: inset 0 0 0 1px rgba(127, 227, 255, 0.4);
+}
+
+.ui-select__option-button--disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
 }
 
 .field--select select.field__input {


### PR DESCRIPTION
## Summary
- restyle the events dropdown to open upward and share a reusable UI-select component
- replace the biome, VIP, and Dave luck selects with matching custom dropdowns
- add JavaScript helpers to populate the new menus and keep them synchronized with existing logic

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68de718b3b04832193ad5cc6f78afdf7