### PR TITLE
Add Oblivion preset dropdown and aura logic

### DIFF
--- a/func.js
+++ b/func.js
@@ -327,7 +327,7 @@ function applyBiomeTheme(biome) {
     }
 }
 
-function setLuck(value) {
+function setLuck(value, options = {}) {
     baseLuck = value;
     currentLuck = value;
     lastVipMultiplier = 1;
@@ -341,6 +341,10 @@ function setLuck(value) {
         refreshCustomSelect('dave-luck-select');
     }
     document.getElementById('luck').value = value;
+
+    if (typeof handlePresetOptionChange === 'function') {
+        handlePresetOptionChange(options);
+    }
 }
 
 function updateLuckValue() {
@@ -367,6 +371,9 @@ function updateLuckValue() {
             document.getElementById('dave-luck-select').value = "1";
             refreshCustomSelect('dave-luck-select');
         }
+        if (typeof handlePresetOptionChange === 'function') {
+            handlePresetOptionChange({});
+        }
         return;
     }
     currentLuck = baseLuck * vipMultiplier * xyzMultiplier * daveMultiplier;
@@ -380,6 +387,9 @@ function resetLuck() {
     document.getElementById('luck').value = 1;
     playSound(document.getElementById('clickSound'), 'ui');
     updateLuckValue();
+    if (typeof handlePresetOptionChange === 'function') {
+        handlePresetOptionChange({});
+    }
 }
 
 function resetRolls() {
@@ -646,6 +656,7 @@ async function playAuraSequence(queue) {
 }
 
 function getRarityClass(aura, biome) {
+    if (aura && aura.disableRarityClass) return '';
     // Special case for Fault
     if (aura && aura.name === "Fault") return 'rarity-challenged';
     if (aura && aura.exclusiveTo && (aura.exclusiveTo.includes("limbo") || aura.exclusiveTo.includes("limbo-null"))) {

--- a/index.html
+++ b/index.html
@@ -47,6 +47,9 @@
     <video id="oppression-cs" class="aura-video" preload="auto">
         <source src="files/oppressionCutscene.webm" type="video/webm">
     </video>
+    <video id="oblivion-cs" class="aura-video" preload="auto">
+        <source src="files/oblivionCutscene.webm" type="video/webm">
+    </video>
 
     <div id="video-overlay" class="video-overlay" aria-hidden="true"></div>
 
@@ -291,7 +294,16 @@
                 <div class="control-group control-group--presets">
                     <div class="preset-grid" id="luck-presets">
                         <button type="button" onclick="setLuck(700000)">Pump King's Blood 700,000×</button>
-                        <button type="button" onclick="setLuck(600000)">Oblivion / Godlike + Bound + Heavenly 600,000×</button>
+                        <details id="oblivion-preset-dropdown" class="preset-dropdown">
+                            <summary class="preset-dropdown__summary">
+                                <span class="preset-dropdown__title">Oblivion / Godlike + Bound + Heavenly 600,000×</span>
+                                <span id="oblivion-preset-selection" class="preset-dropdown__selection preset-dropdown__selection--placeholder">Select preset</span>
+                            </summary>
+                            <div class="preset-dropdown__options">
+                                <button type="button" onclick="applyOblivionPreset('oblivion')">Oblivion Potion Preset 600,000×</button>
+                                <button type="button" onclick="applyOblivionPreset('classic')">Godlike + Heavenly + Bound 600,000×</button>
+                            </div>
+                        </details>
                         <button type="button" onclick="setLuck(400000)">Godlike Potion 400,000×</button>
                         <button type="button" id="void-heart-btn" style="display:none;" onclick="setLuck(300000)">Void Heart 300,000×</button>
                         <button type="button" onclick="setLuck(200000)">Heavenly + Bound 200,000×</button>

--- a/style.css
+++ b/style.css
@@ -881,6 +881,91 @@ select.field__input option {
     transform: translateY(-1px);
 }
 
+.preset-dropdown {
+    position: relative;
+    border-radius: 10px;
+    border: 1px solid rgba(95, 160, 230, 0.35);
+    background: rgba(6, 12, 24, 0.85);
+    color: var(--text-primary);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    width: 100%;
+    margin: 0;
+    overflow: hidden;
+}
+
+.preset-dropdown[open] {
+    border-color: var(--accent);
+    box-shadow: inset 0 0 16px rgba(127, 227, 255, 0.2);
+}
+
+.preset-dropdown__summary {
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
+    padding: 10px 36px 10px 12px;
+    font-family: inherit;
+    font-size: 11px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    cursor: pointer;
+    color: var(--text-primary);
+    position: relative;
+}
+
+.preset-dropdown__summary::-webkit-details-marker {
+    display: none;
+}
+
+.preset-dropdown__summary::after {
+    content: '\25BC';
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 11px;
+    opacity: 0.7;
+    transition: transform 0.2s ease;
+}
+
+.preset-dropdown[open] .preset-dropdown__summary::after {
+    transform: translateY(-50%) rotate(180deg);
+}
+
+.preset-dropdown__summary:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.preset-dropdown__title {
+    font-weight: 600;
+}
+
+.preset-dropdown__selection {
+    font-size: 10px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--text-secondary);
+}
+
+.preset-dropdown__selection--placeholder {
+    color: rgba(199, 219, 255, 0.48);
+}
+
+.preset-dropdown__options {
+    display: grid;
+    gap: 8px;
+    padding: 8px 12px 12px;
+    border-top: 1px solid rgba(95, 160, 230, 0.35);
+    background: rgba(4, 10, 22, 0.95);
+}
+
+.preset-dropdown__options button {
+    width: 100%;
+    text-align: left;
+}
+
 .preset-footer {
     position: relative;
     margin-top: clamp(12px, 2vw, 20px);
@@ -1109,6 +1194,15 @@ select.field__input option {
 .rarity-transcendent { color: #afeeee; text-shadow: 1px 1px 2px #000; }
 .rarity-challenged { color: #000000; text-shadow: -1px -1px 0 #fff, 1px -1px 0 #fff, -1px 1px 0 #fff, 1px 1px 0 #fff; }
 .rarity-limbo { color: #000; text-shadow: 0 0 2px #aaa, 0 0 4px #aaa, 1px 1px 0 #aaa, -1px -1px 0 #aaa; }
+
+.aura-subtitle {
+    display: block;
+    font-size: 0.85em;
+    letter-spacing: 0.08em;
+    text-transform: none;
+    color: var(--text-secondary);
+    font-style: italic;
+}
 
 .aura-event-text {
   color: #fff !important;


### PR DESCRIPTION
## Summary
- replace the 600k luck quick preset button with a dropdown that separates the Oblivion potion preset from the Godlike + Heavenly + Bound setup and add supporting UI polish
- introduce the Oblivion aura with a fixed 1-in-2,000 roll chance, subtitle styling, and hook it into the cutscene priority
- keep the preset selection state in sync when adjusting luck so the special aura only activates for the Oblivion preset

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e41fae8f4c83218e0ecba83c748892