### PR TITLE
Highlight Oblivion aura

### DIFF
--- a/func.js
+++ b/func.js
@@ -707,6 +707,7 @@ function getAuraStyleClass(aura) {
     if (!name) return '';
 
     const classes = [];
+    if (name.startsWith('Oblivion')) classes.push('aura-effect-oblivion');
     if (name.startsWith('Pixelation')) classes.push('aura-effect-pixelation');
     if (name.startsWith('Luminosity')) classes.push('aura-effect-luminosity');
     if (name.startsWith('Equinox')) classes.push('aura-effect-equinox');

--- a/index.html
+++ b/index.html
@@ -32,6 +32,9 @@
     <audio id="100mSound" loop muted src="files/100_000_000Roll.ogg" type="audio/ogg"></audio>
     <audio id="limbo99mSound" loop muted src="files/99mLimboRollSound.mp3" type="audio/mpeg" data-boost="6.7"></audio>
 
+    <video id="oblivion-cs" class="aura-video" preload="auto">
+        <source src="files/oblivionCutscene.webm" type="video/webm">
+    </video>
     <video id="equinox-cs" class="aura-video" preload="auto">
         <source src="files/equinoxCutscene.webm" type="video/webm">
     </video>
@@ -46,9 +49,6 @@
     </video>
     <video id="oppression-cs" class="aura-video" preload="auto">
         <source src="files/oppressionCutscene.webm" type="video/webm">
-    </video>
-    <video id="oblivion-cs" class="aura-video" preload="auto">
-        <source src="files/oblivionCutscene.webm" type="video/webm">
     </video>
 
     <div id="video-overlay" class="video-overlay" aria-hidden="true"></div>

--- a/script.js
+++ b/script.js
@@ -65,7 +65,13 @@ function renderAuraName(aura, overrideName) {
     return baseName;
 }
 
+function getResultSortChance(aura, baseChance) {
+    if (!aura) return baseChance;
+    return aura.name === OBLIVION_AURA_NAME ? Number.POSITIVE_INFINITY : baseChance;
+}
+
 const auras = [
+    { name: "Oblivion", chance: 2000, requiresOblivionPreset: true, ignoreLuck: true, fixedRollThreshold: 1, subtitle: "The Truth Seeker", cutscene: "oblivion-cs", disableRarityClass: true },
     { name: "Equinox - 2,500,000,000", chance: 2500000000, cutscene: "equinox-cs" },
     { name: "Luminosity - 1,200,000,000", chance: 1200000000, cutscene: "lumi-cs" },
     { name: "Pixelation - 1,073,741,824", chance: 1073741824, cutscene: "pixelation-cs" },
@@ -236,7 +242,6 @@ const auras = [
     { name: "Glacier - 2,304", chance: 2304, breakthrough: { snowy: 3 } },
     { name: "Ash - 2,300", chance: 2300 },
     { name: "Magnetic - 2,048", chance: 2048 },
-    { name: "Oblivion", chance: 2000, requiresOblivionPreset: true, ignoreLuck: true, fixedRollThreshold: 1, subtitle: "The Truth Seeker", cutscene: "oblivion-cs", disableRarityClass: true },
     { name: "Glock - 1,700", chance: 1700 },
     { name: "Atomic - 1,180", chance: 1180 },
     { name: "Precious - 1,024", chance: 1024 },
@@ -884,18 +889,18 @@ function roll() {
                         const nativeLabel = renderAuraName(aura, btName);
                         resultEntries.push({
                             label: `<span class="${classAttr}">[Native] ${nativeLabel} | Times Rolled: ${btAuras[aura.name].count.toLocaleString()}</span>`,
-                            chance: btAuras[aura.name].btChance
+                            chance: getResultSortChance(aura, btAuras[aura.name].btChance)
                         });
                         if (aura.wonCount > btAuras[aura.name].count) {
                             resultEntries.push({
                                 label: `<span class="${classAttr}">${formattedName} | Times Rolled: ${(aura.wonCount - btAuras[aura.name].count).toLocaleString()}</span>`,
-                                chance: aura.chance
+                                chance: getResultSortChance(aura, aura.chance)
                             });
                         }
                     } else {
                         resultEntries.push({
                             label: `<span class="${classAttr}">${formattedName} | Times Rolled: ${aura.wonCount.toLocaleString()}</span>`,
-                            chance: aura.chance
+                            chance: getResultSortChance(aura, aura.chance)
                         });
                     }
                 }

--- a/style.css
+++ b/style.css
@@ -1280,11 +1280,20 @@ select.field__input option {
         -1px -1px 0 rgba(40, 90, 140, 0.85);
 }
 
+.aura-effect-oblivion,
 .aura-effect-pixelation,
 .aura-effect-luminosity,
 .aura-effect-equinox {
     display: inline-block;
     position: relative;
+}
+
+.aura-effect-oblivion {
+    background: linear-gradient(92deg, #bb7aff 0%, #401768 40%, #26063c 100%);
+    color: transparent;
+    -webkit-background-clip: text;
+    background-clip: text;
+    text-shadow: 0 0 16px rgba(187, 122, 255, 0.45);
 }
 
 .aura-effect-pixelation {


### PR DESCRIPTION
## Summary
- style the Oblivion aura output with a purple gradient accent
- ensure Oblivion data and cutscene surface first when rolled
- prioritize Oblivion entries in the roll results ordering

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e42b2efab88321b6961f4e68e91529