### PR TITLE
Add Memory aura special reward for Oblivion potion

### DIFF
--- a/func.js
+++ b/func.js
@@ -708,6 +708,7 @@ function getAuraStyleClass(aura) {
 
     const classes = [];
     if (name.startsWith('Oblivion')) classes.push('aura-effect-oblivion');
+    if (name.startsWith('Memory')) classes.push('aura-effect-memory');
     if (name.startsWith('Pixelation')) classes.push('aura-effect-pixelation');
     if (name.startsWith('Luminosity')) classes.push('aura-effect-luminosity');
     if (name.startsWith('Equinox')) classes.push('aura-effect-equinox');

--- a/index.html
+++ b/index.html
@@ -35,6 +35,9 @@
     <video id="oblivion-cs" class="aura-video" preload="auto">
         <source src="files/oblivionCutscene.webm" type="video/webm">
     </video>
+    <video id="memory-cs" class="aura-video" preload="auto">
+        <source src="files/memoryCutscene.webm" type="video/webm">
+    </video>
     <video id="equinox-cs" class="aura-video" preload="auto">
         <source src="files/equinoxCutscene.webm" type="video/webm">
     </video>

--- a/style.css
+++ b/style.css
@@ -1281,6 +1281,7 @@ select.field__input option {
 }
 
 .aura-effect-oblivion,
+.aura-effect-memory,
 .aura-effect-pixelation,
 .aura-effect-luminosity,
 .aura-effect-equinox {
@@ -1294,6 +1295,14 @@ select.field__input option {
     -webkit-background-clip: text;
     background-clip: text;
     text-shadow: 0 0 16px rgba(187, 122, 255, 0.45);
+}
+
+.aura-effect-memory {
+    background: linear-gradient(110deg, #f3d9ff 0%, #a26bff 45%, #3b1061 100%);
+    color: transparent;
+    -webkit-background-clip: text;
+    background-clip: text;
+    text-shadow: 0 0 20px rgba(200, 140, 255, 0.55);
 }
 
 .aura-effect-pixelation {


### PR DESCRIPTION
## Summary
- add the Memory special aura as an Oblivion potion reward with The Fallen subtitle and dedicated cutscene
- prioritize Memory between Oblivion and Equinox results and support the new video trigger
- update the UI styling to highlight Memory with a brighter purple gradient

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e42d92856c832192e75c9bd20e9e10