### PR TITLE
Fix Memory aura roll odds for Oblivion preset

### DIFF
--- a/func.js
+++ b/func.js
@@ -708,6 +708,7 @@ function getAuraStyleClass(aura) {
 
     const classes = [];
     if (name.startsWith('Oblivion')) classes.push('aura-effect-oblivion');
+    if (name.startsWith('Memory')) classes.push('aura-effect-memory');
     if (name.startsWith('Pixelation')) classes.push('aura-effect-pixelation');
     if (name.startsWith('Luminosity')) classes.push('aura-effect-luminosity');
     if (name.startsWith('Equinox')) classes.push('aura-effect-equinox');

--- a/index.html
+++ b/index.html
@@ -35,6 +35,9 @@
     <video id="oblivion-cs" class="aura-video" preload="auto">
         <source src="files/oblivionCutscene.webm" type="video/webm">
     </video>
+    <video id="memory-cs" class="aura-video" preload="auto">
+        <source src="files/memoryCutscene.webm" type="video/webm">
+    </video>
     <video id="equinox-cs" class="aura-video" preload="auto">
         <source src="files/equinoxCutscene.webm" type="video/webm">
     </video>

--- a/script.js
+++ b/script.js
@@ -8,11 +8,14 @@ const customSelectRegistry = new Map();
 const OBLIVION_PRESET_KEY = 'oblivion';
 const OBLIVION_PRESET_LUCK = 600000;
 const OBLIVION_AURA_NAME = 'Oblivion';
+const OBLIVION_MEMORY_AURA_NAME = 'Memory';
 const OBLIVION_POTION_ROLL_ODDS = 2000;
+const OBLIVION_MEMORY_ROLL_ODDS = 100;
 
 let isOblivionPresetActive = false;
 let activeOblivionPresetLabel = 'Select preset';
 let oblivionAuraDefinition = null;
+let memoryAuraDefinition = null;
 
 function applyOblivionPreset(presetKey) {
     const options = {};
@@ -67,11 +70,14 @@ function renderAuraName(aura, overrideName) {
 
 function getResultSortChance(aura, baseChance) {
     if (!aura) return baseChance;
-    return aura.name === OBLIVION_AURA_NAME ? Number.POSITIVE_INFINITY : baseChance;
+    if (aura.name === OBLIVION_AURA_NAME) return Number.POSITIVE_INFINITY;
+    if (aura.name === OBLIVION_MEMORY_AURA_NAME) return Number.MAX_SAFE_INTEGER;
+    return baseChance;
 }
 
 const auras = [
     { name: "Oblivion", chance: 2000, requiresOblivionPreset: true, ignoreLuck: true, fixedRollThreshold: 1, subtitle: "The Truth Seeker", cutscene: "oblivion-cs", disableRarityClass: true },
+    { name: "Memory", chance: 200000, requiresOblivionPreset: true, ignoreLuck: true, fixedRollThreshold: 1, subtitle: "The Fallen", cutscene: "memory-cs", disableRarityClass: true },
     { name: "Equinox - 2,500,000,000", chance: 2500000000, cutscene: "equinox-cs" },
     { name: "Luminosity - 1,200,000,000", chance: 1200000000, cutscene: "lumi-cs" },
     { name: "Pixelation - 1,073,741,824", chance: 1073741824, cutscene: "pixelation-cs" },
@@ -350,9 +356,10 @@ for (const [eventId, auraNames] of Object.entries(EVENT_AURA_MAP)) {
     });
 }
 
-const cutscenePriority = ["oblivion-cs", "equinox-cs", "lumi-cs", "pixelation-cs", "dreammetric-cs", "oppression-cs"];
+const cutscenePriority = ["oblivion-cs", "memory-cs", "equinox-cs", "lumi-cs", "pixelation-cs", "dreammetric-cs", "oppression-cs"];
 
 oblivionAuraDefinition = auras.find(aura => aura.name === OBLIVION_AURA_NAME) || null;
+memoryAuraDefinition = auras.find(aura => aura.name === OBLIVION_MEMORY_AURA_NAME) || null;
 
 const ROE_EXCLUDED_AURAS = new Set([
     "Apostolos : Veil - 800,000,000",
@@ -768,6 +775,7 @@ function roll() {
     }
 
     const activeOblivionAura = (isOblivionPresetActive && luckValue >= OBLIVION_PRESET_LUCK) ? oblivionAuraDefinition : null;
+    const activeMemoryAura = (isOblivionPresetActive && luckValue >= OBLIVION_PRESET_LUCK) ? memoryAuraDefinition : null;
 
     const CHUNK_SIZE = 100000;
     let currentRoll = 0;
@@ -776,12 +784,15 @@ function roll() {
         const chunkEnd = Math.min(currentRoll + CHUNK_SIZE, total);
         
         for (let i = currentRoll; i < chunkEnd; i++) {
-            if (activeOblivionAura) {
-                if (Random(1, OBLIVION_POTION_ROLL_ODDS) === 1) {
-                    activeOblivionAura.wonCount++;
-                    rolls++;
-                    continue;
-                }
+            if (activeMemoryAura && Random(1, OBLIVION_MEMORY_ROLL_ODDS) === 1) {
+                activeMemoryAura.wonCount++;
+                rolls++;
+                continue;
+            }
+            if (activeOblivionAura && Random(1, OBLIVION_POTION_ROLL_ODDS) === 1) {
+                activeOblivionAura.wonCount++;
+                rolls++;
+                continue;
             }
             for (let aura of effectiveAuras) {
                 let chance = aura.effectiveChance;

--- a/style.css
+++ b/style.css
@@ -1281,6 +1281,7 @@ select.field__input option {
 }
 
 .aura-effect-oblivion,
+.aura-effect-memory,
 .aura-effect-pixelation,
 .aura-effect-luminosity,
 .aura-effect-equinox {
@@ -1294,6 +1295,14 @@ select.field__input option {
     -webkit-background-clip: text;
     background-clip: text;
     text-shadow: 0 0 16px rgba(187, 122, 255, 0.45);
+}
+
+.aura-effect-memory {
+    background: linear-gradient(110deg, #f3d9ff 0%, #a26bff 45%, #3b1061 100%);
+    color: transparent;
+    -webkit-background-clip: text;
+    background-clip: text;
+    text-shadow: 0 0 20px rgba(200, 140, 255, 0.55);
 }
 
 .aura-effect-pixelation {


### PR DESCRIPTION
## Summary
- trigger Memory aura directly with a 1-in-100 roll when the Oblivion preset is active
- fall back to the existing 1-in-2,000 Oblivion aura roll when Memory does not occur

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e42d92856c832192e75c9bd20e9e10