### PR TITLE
Update version to v1.810 and remove April Fools event

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,11 +171,11 @@
                 <div class="banner__meta">
                     <h1 class="banner__title">Sol's RNG Rolling Simulator</h1>
                     <p class="banner__subtitle">
-                        <button type="button" class="banner__version-button" id="versionInfoButton" aria-haspopup="dialog" aria-expanded="false" data-version-id="v1801">v1.801</button>
+                        <button type="button" class="banner__version-button" id="versionInfoButton" aria-haspopup="dialog" aria-expanded="false" data-version-id="v1810">v1.810</button>
                         <span class="banner__subtitle-divider" aria-hidden="true">◉</span>
                         <span class="banner__subtitle-author">By <span class="banner__subtitle-author-name"><a href="https://discord.com/users/611204110955446301" target="_blank" rel="noopener">not.unnamed</a></span></span>
                         <span class="banner__subtitle-divider" aria-hidden="true">◉</span>
-                        <span class="banner__subtitle-updated">Updated <time datetime="2026-04-30T12:00:00+02:00">2026/04/30 12:30 PM CEST</time></span>
+                        <span class="banner__subtitle-updated">Updated <time datetime="2026-04-30T12:00:00+02:00">2026/05/05 10:20 AM CEST</time></span>
                         <span class="banner__subtitle-divider" aria-hidden="true">◉</span>
                         <span class="banner__subtitle-eon"><span class="banner__subtitle-game-version"><a href="https://www.roblox.com/games/15532962292/Sols-RNG" target="_blank" rel="noopener">Sol's RNG Eon 1-20</a></span></span>
                     </p>
@@ -1097,7 +1097,7 @@
             </div>
 
             <div class="changelog-modal__panels" data-changelog-panels>
-                <!-- <section
+                <section
                     id="changelog-panel-v1810"
                     class="changelog-modal__panel"
                     role="tabpanel"
@@ -1109,7 +1109,7 @@
                     <header class="changelog-modal__header">
                         <h2 class="changelog-modal__title">Version v1.810 Update Notes</h2>
                         <span class="changelog-tab__subtitle">April Fools Ends</span>
-                        <p class="changelog-modal__meta">Updated 2026/05/02 at 12:30 PM CEST</p>
+                        <p class="changelog-modal__meta">Updated 2026/05/04 at 10:20 AM CEST</p>
                     </header>
                     <p class="changelog-modal__intro">Latest changes:</p>
                     <ul class="changelog-modal__list">
@@ -1117,7 +1117,7 @@
                         <li><span class="largeClass"><span class="sigil-outline-easter-2026">Easter Event 2026</span> stays default enabled for a little longer.</span></li>
                     </ul>
                     <p>If there's any bugs you encounter, please DM me here <a href="https://discord.com/users/611204110955446301" class="subtitleClass" target="_blank" rel="noopener">@not.unnamed</a></p>
-                </section> -->
+                </section>
                 
                 <section
                     id="changelog-panel-v1800"

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -5005,7 +5005,7 @@ const EVENT_BIOME_CONDITION_MESSAGES = Object.freeze({
     unknown: 'Requires Dev Biomes to be enabled under run parameters.',
 });
 
-const enabledEvents = new Set(['aprilFools26', 'easter26']);
+const enabledEvents = new Set(['easter26']);
 const auraEventIndex = new Map();
 
 function hasAnyEnabledEvent(eventIds) {


### PR DESCRIPTION
Update the version number to v1.810, adjust timestamps in the changelog, and remove the April Fools event from the list of enabled events.